### PR TITLE
fix: update typo in CSS output file name

### DIFF
--- a/practicas/dark-mode - inicio/package.json
+++ b/practicas/dark-mode - inicio/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "tailDev": "npx tailwindcss -i ./src/css/tailwind.css -o ./src/css/estillos.css --watch"
+    "tailDev": "npx tailwindcss -i ./src/css/tailwind.css -o ./src/css/estilos.css --watch"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- [x] Change CSS output file name estillos.css for estilos.css

When you execute the project you cannot see tailwind styles applied, because "estillos.css" is different to "estilos.css" in HTML file

Cuando ejecutas el projecto no se visualizan los estilos de tailwind porque "estillos.css" es diferente a "estilos.css" en el archivo HTML.